### PR TITLE
Updated StoreMixin to use 'var' instead of 'const'

### DIFF
--- a/StoreMixin.js
+++ b/StoreMixin.js
@@ -1,7 +1,7 @@
-const StoreMixin = {
+var StoreMixin = {
     getInitialState: function() {
         if (!this.getStoreState) {
-            const err = new Error('Require `getStoreState()` when using `StoreMixin`');
+            var err = new Error('Require `getStoreState()` when using `StoreMixin`');
             console.warn(err.stack);
         }
 


### PR DESCRIPTION
Needed backwards compatibility with IE10 and lower, and this seemed to be the solution.
