### PR TITLE
Fix error in checking for localStorage

### DIFF
--- a/lib/localStorage.js
+++ b/lib/localStorage.js
@@ -1,26 +1,26 @@
 var hasLocalStorage = function() {
-	try {
-		return typeof window !== 'undefined' && window.localStorage;
-	} catch(e) {
-		return false;
-	}
+    try {
+        return typeof window !== 'undefined' && window.localStorage;
+    } catch(e) {
+        return false;
+    }
 }
 
 var _localStorage = {
     getItem: function(key) {
-        if (!hasLocalStorage()) {
+        if (!hasLocalStorage()) { return null; }
         try {
             return window.localStorage.getItem(key);
         } catch(e) {
-		    return null;
-	    }
+            return null;
+        }
     },
     setItem: function(key, value) {
         if (!hasLocalStorage()) { return null; }
         try {
             return window.localStorage.setItem(key, value);
         } catch(e) {
-		    return null;
-	    }
+            return null;
+        }
     }
 };

--- a/lib/localStorage.js
+++ b/lib/localStorage.js
@@ -1,17 +1,26 @@
-// Check for localStorage support
-var hasLocalStorage = typeof window !== 'undefined' && window.localStorage;
+var hasLocalStorage = function() {
+	try {
+		return typeof window !== 'undefined' && window.localStorage;
+	} catch(e) {
+		return false;
+	}
+}
 
 var _localStorage = {
     getItem: function(key) {
-        if (!hasLocalStorage) { return null; }
-
-        return window.localStorage.getItem(key);
+        if (!hasLocalStorage()) {
+        try {
+            return window.localStorage.getItem(key);
+        } catch(e) {
+		    return null;
+	    }
     },
     setItem: function(key, value) {
-        if (!hasLocalStorage) { return null; }
-
-        return window.localStorage.setItem(key, value);
+        if (!hasLocalStorage()) { return null; }
+        try {
+            return window.localStorage.setItem(key, value);
+        } catch(e) {
+		    return null;
+	    }
     }
 };
-
-module.exports = _localStorage;


### PR DESCRIPTION
iPad private browsing mode or explicitly disabled localStorage on Chrome or Firefox error out when even trying to check window.localStorage. Safari private browsing mode doesn't disable localStorage but sets it's quota to zero, so any calls to setItem throw an out of quota exception.
