### PR TITLE
Remove invocation of isMounted(), which now spits out console errors

### DIFF
--- a/StoreMixin.js
+++ b/StoreMixin.js
@@ -8,14 +8,16 @@ var StoreMixin = {
         return this.getStoreState();
     },
     componentDidMount: function() {
-        // Make sure state is up-to-date
-        this.onStoreChange();
+        this._isMounted = true;
     },
     onStoreChange: function() {
-        if (this.isMounted()) {
+        if (this._isMounted) {
             this.setState(this.getStoreState());
         }
-    }
+    },
+    componentWillUnmount: function() {
+        this._isMounted = false;
+    },
 };
 
 module.exports = StoreMixin;

--- a/StoreMixin.js
+++ b/StoreMixin.js
@@ -9,6 +9,9 @@ var StoreMixin = {
     },
     componentDidMount: function() {
         this._isMounted = true;
+
+        // Make sure state is up-to-date
+        this.onStoreChange();
     },
     onStoreChange: function() {
         if (this._isMounted) {


### PR DESCRIPTION
I followed the 'easy migration strategy' defined here: https://facebook.github.io/react/blog/2015/12/16/ismounted-antipattern.html